### PR TITLE
slight speed up

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -29,8 +29,8 @@ end
 function +(v1::LorentzVectorCyl{T}, v2::LorentzVectorCyl{W}) where {T,W}
     m1, m2 = max(v1.mass, zero(v1.pt)), max(v2.mass, zero(v2.pt))
     
-    px1, px2 = px(v1), px(v2)
-    py1, py2 = py(v1), py(v2)
+    py1, px1 = v1.pt .* sincos(v1.phi)
+    py2, px2 = v2.pt .* sincos(v2.phi)
     pz1, pz2 = pz(v1), pz(v2)
     e1 = sqrt(px1^2 + py1^2 + pz1^2 + m1^2)
     e2 = sqrt(px2^2 + py2^2 + pz2^2 + m2^2)

--- a/src/main.jl
+++ b/src/main.jl
@@ -32,8 +32,8 @@ function +(v1::LorentzVectorCyl{T}, v2::LorentzVectorCyl{W}) where {T,W}
     py1, px1 = v1.pt .* sincos(v1.phi)
     py2, px2 = v2.pt .* sincos(v2.phi)
     pz1, pz2 = pz(v1), pz(v2)
-    e1 = sqrt(px1^2 + py1^2 + pz1^2 + m1^2)
-    e2 = sqrt(px2^2 + py2^2 + pz2^2 + m2^2)
+    e1 = sqrt(v1.pt^2 + pz1^2 + m1^2)
+    e2 = sqrt(v2.pt^2 + pz2^2 + m2^2)
     
     sumpx = px1+px2
     sumpy = py1+py2


### PR DESCRIPTION
Compute sine and cosine together (sin(x)^2+cos(x)^2=1).

README example speeds up by ~8%

```julia
julia> using LVCyl, BenchmarkTools
julia> v1 = LorentzVectorCyl(43.71242f0, 1.4733887f0, 1.6855469f0, 0.10571289f0);
julia> v2 = LorentzVectorCyl(36.994347f0, 0.38684082f0, -1.3935547f0, 0.10571289f0);
julia> @btime ($v1+$v2).mass # before
  83.063 ns (0 allocations: 0 bytes)
julia> @btime ($v1+$v2).mass # after
  76.602 ns (0 allocations: 0 bytes)
```